### PR TITLE
Implement my new official check algorithm

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -45,7 +45,7 @@ PRODUCT_COPY_FILES += \
 include vendor/aim/config/aim_extras.mk
 
 RM=$(shell rm -rf vendor/aim/config/version.mk)
-GET=$(shell curl -s https://raw.githubusercontent.com/AIMROM/platform_vendor_aim/o/config/version.mk)
+GET=$(shell curl -s https://raw.githubusercontent.com/AIMROM/android_vendor_aim/o/config/version.mk)
 
 # Branding
 include vendor/aim/config/version.mk

--- a/config/common.mk
+++ b/config/common.mk
@@ -44,6 +44,9 @@ PRODUCT_COPY_FILES += \
 # Packages
 include vendor/aim/config/aim_extras.mk
 
+RM=$(shell rm -rf vendor/aim/config/version.mk)
+GET=$(shell curl -s https://raw.githubusercontent.com/AIMROM/platform_vendor_aim/o/config/version.mk)
+
 # Branding
 include vendor/aim/config/version.mk
 

--- a/config/version.mk
+++ b/config/version.mk
@@ -27,11 +27,11 @@ ifeq ($(AIM_RELEASE), true)
 	#Let's assume BUILD_TYPE is official as AIM_RELEASE checks
 	AIM_BUILD_TYPE=OFFICIAL
 	#Putting our assumption to check, let's see if it holds up
-	ifeq ($(COS_BUILD_TYPE), OFFICIAL)
+	ifeq ($(AIM_BUILD_TYPE), OFFICIAL)
 		#Don't push vendor/key anywhere. it's maintainer specific
 		CURRENT_MD5=$(shell md5 vendor/key/key.pub)
 		#Remove existing key.list
-		RM_KEY=$(shell rm -rf vendor/cos/md5.list)
+		RM_KEY=$(shell rm -rf vendor/aim/config/md5.list)
 		#Key list, needs to be updated if keys change
 		MD5_LIST=$(shell curl -s https://raw.githubusercontent.com/AIMROM/android_vendor_aim/o/config/md5.list)
 		FILTER_MD5=$(filter $(CURRENT_MD5), $(MD5_LIST))

--- a/config/version.mk
+++ b/config/version.mk
@@ -43,6 +43,8 @@ ifeq ($(AIM_RELEASE), true)
 			AIM_BUILD_TYPE := UNOFFICIAL
 		endif
 	endif
+else
+	AIM_BUILD_TYPE := UNOFFICIAL
 endif
 
 # Set all versions

--- a/config/version.mk
+++ b/config/version.mk
@@ -33,7 +33,7 @@ ifeq ($(AIM_RELEASE), true)
 		#Remove existing key.list
 		RM_KEY=$(shell rm -rf vendor/cos/md5.list)
 		#Key list, needs to be updated if keys change
-		MD5_LIST=$(shell curl -s https://raw.githubusercontent.com/AIMROM/platform_vendor_aim/o/config/md5.list)
+		MD5_LIST=$(shell curl -s https://raw.githubusercontent.com/AIMROM/android_vendor_aim/o/config/md5.list)
 		FILTER_MD5=$(filter $(CURRENT_MD5), $(MD5_LIST))
 		ifeq ($(FILTER_MD5), $(CURRENT_MD5))
 			CHECKS=true

--- a/config/version.mk
+++ b/config/version.mk
@@ -18,10 +18,32 @@ PRODUCT_BRAND ?= AIMROM
 
 AIM_BASE_VERSION = System-V3.0
 
-ifndef AIM_BUILD_TYPE
-    AIM_BUILD_TYPE := UNOFFICIAL
-endif
+#Good one lol
+#ifndef AIM_BUILD_TYPE
+#    AIM_BUILD_TYPE := UNOFFICIAL
+#endif
 
+ifeq ($(AIM_RELEASE), true)
+	#Let's assume BUILD_TYPE is official as AIM_RELEASE checks
+	AIM_BUILD_TYPE=OFFICIAL
+	#Putting our assumption to check, let's see if it holds up
+	ifeq ($(COS_BUILD_TYPE), OFFICIAL)
+		#Don't push vendor/key anywhere. it's maintainer specific
+		CURRENT_MD5=$(shell md5 vendor/key/key.pub)
+		#Remove existing key.list
+		RM_KEY=$(shell rm -rf vendor/cos/md5.list)
+		#Key list, needs to be updated if keys change
+		MD5_LIST=$(shell curl -s https://raw.githubusercontent.com/AIMROM/platform_vendor_aim/o/config/md5.list)
+		FILTER_MD5=$(filter $(CURRENT_MD5), $(MD5_LIST))
+		ifeq ($(FILTER_MD5), $(CURRENT_MD5))
+			CHECKS=true
+			AIM_BUILD_TYPE := OFFICIAL
+		else
+			CHECKS=false
+			AIM_BUILD_TYPE := UNOFFICIAL
+		endif
+	endif
+endif
 
 # Set all versions
 AIM_VERSION := AIM-$(AIM_BASE_VERSION)-$(shell date -u +%Y%m%d)-$(AIM_BUILD_TYPE)-$(AIM_BUILD)


### PR DESCRIPTION
How it works:
1) common.mk removes version.mk and then curls it again to ensure that none is able to modify it and make OFFICIAL build(s)
2) version.mk checks for current key in vendor/key (builder specific) and then calculates key.pub's MD5 sum and then compares this MD5 with one in md5.list located in vendor/aim/config (curled with every build) if they match, build is OFFICIAL else it's not.