### PR TITLE
Disable top left/right statusbar and navbar icons padding

### DIFF
--- a/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -37,5 +37,9 @@
 
     <!-- The duration in seconds to wait before the dismiss buttons are shown. -->
     <integer name="recents_task_bar_dismiss_delay_seconds">0</integer>
+     
+     <!-- Disable top left/right statusbar and navbar icons padding -->
+     <dimen name="nav_content_padding">0dp</dimen>
+     <dimen name="rounded_corner_content_padding">0dp</dimen>
 
 </resources>


### PR DESCRIPTION
Thanks to Ezio for this commit!
Non-rounded screen devices don't need the padding and we don't have Pissel 2 on our supported devices (yet)